### PR TITLE
Changed "https://t.me/" to "tg://"

### DIFF
--- a/underhanded.sh
+++ b/underhanded.sh
@@ -216,7 +216,7 @@ app_redir="https://bdo.to/u/abcdef"
 elif [ "$catchapp" -eq 8 ];then
 
 app="Telegram"
-app_redir="https://t.me/"
+app_redir="tg://"
 elif [ "$catchapp" -eq 9 ];then
 
 app="Netflix"


### PR DESCRIPTION
By using "https://t.me/" link follows to telegram website, not app.
"tg://" asking to open telegram app.